### PR TITLE
Pass third arg to save_post action to match core

### DIFF
--- a/expiring-posts.php
+++ b/expiring-posts.php
@@ -361,7 +361,7 @@ class EXP_Expiring_Posts {
 		wp_transition_post_status( 'expired', $old_status, $post );
 
 		do_action( 'edit_post', $post->ID, $post );
-		do_action( 'save_post', $post->ID, $post );
+		do_action( 'save_post', $post->ID, $post, true );
 		do_action( 'wp_insert_post', $post->ID, $post );
 
 	}


### PR DESCRIPTION
Here's core's hook:

```
/**
 * Fires once a post has been saved.
 *
 * @since 1.5.0
 *
 * @param int     $post_ID Post ID.
 * @param WP_Post $post    Post object.
 * @param bool    $update  Whether this is an existing post being updated or not.
 */
do_action( 'save_post', $post_ID, $post, $update );
```

This is needed so that other plugins/themes that hook into `save_post` and expect 3 args won't encounter a 'missing arguments' warning. Especially important for PHP 7.1 where this will become a fatal error.